### PR TITLE
Reduce the number of rounds Hash makes for testing to speed up test suite

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -17,6 +17,8 @@ trait CreatesApplication
 
         $app->make(Kernel::class)->bootstrap();
 
+        \Hash::setRounds(4);
+
         return $app;
     }
 }


### PR DESCRIPTION
Hello

I've been using this for a while but I also saw Taylor tweet about this recently. For me, on a new iMac running the entire test suite, it gives me about a 40% speed increase.